### PR TITLE
Ensure that the test file exists when checking ingress route

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -156,6 +156,9 @@ class CertbotK8sCharm(charm.CharmBase):
         # Ensure that the Pebble layer is properly configured before continuing.
         self._ensure_pebble_layer()
 
+        # Ensure that the test file needed to check the ingress route exists.
+        self._setup_ingress_check_file()
+
         if not self._check_ingress_route(hostname):
             raise CertbotK8sError("Cannot reach test file using Ingress Route.")
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -259,6 +259,11 @@ class TestCertbotK8sCharm(unittest.TestCase):
         self._add_relation("ingress", "nginx-ingress-integrator", {})
         self.harness.update_config({"email": "foo@li.sh", "agree-tos": True})
 
+        # Resetting after update_config, where these may have been called.
+        mock_resolve_host.reset_mock()
+        mock_setup_ingress.reset_mock()
+        mock_check_ingress.reset_mock()
+
         mock_event = mock.Mock()
 
         with self.assertRaises(charm.CertbotK8sError) as cm:


### PR DESCRIPTION
When running the ``renew-certificate`` action, the ``_check_ingress_route`` check may fail with a 404 error because the file does not exist.

This may occur when the ``nginx`` container has been destroyed and recreated, being ephemeral. We now make sure that that file exists before checking the ingress route.